### PR TITLE
Fix Rotation problem (No Need Two Trail)

### DIFF
--- a/MainScene.tscn
+++ b/MainScene.tscn
@@ -47,15 +47,6 @@ script = ExtResource("2_n6xy7")
 lifespan = 2.0
 startColor = Color(1, 0.380392, 0.34902, 1)
 
-[node name="Trail3D2" type="MeshInstance3D" parent="CharacterBody3D"]
-transform = Transform3D(-4.37114e-08, -1, 0, 1, -4.37114e-08, 0, 0, 0, 1, 0, 0, 0)
-material_override = SubResource("StandardMaterial3D_hftvf")
-cast_shadow = 0
-skeleton = NodePath("../..")
-script = ExtResource("2_n6xy7")
-lifespan = 2.0
-startColor = Color(1, 0.380392, 0.34902, 1)
-
 [node name="Camera3D" type="Camera3D" parent="CharacterBody3D"]
 transform = Transform3D(1, 0, 0, 0, 0.961579, 0.27453, 0, -0.27453, 0.961579, 0, 3.27054, 9.00701)
 

--- a/Trail3D.gd
+++ b/Trail3D.gd
@@ -72,6 +72,10 @@ func _process(delta):
 	mesh.surface_end()
 
 func appendPoint():
+	var direction = get_global_transform().origin - oldPos
+	direction = direction.normalized()
+	rotation.y = atan2(direction.x, direction.z)
+	
 	points.append(get_global_transform().origin)
 	widths.append([
 		get_global_transform().basis.x * fromWidth,


### PR DESCRIPTION
Trail can operate on a single axis since it is not given a rotation depending on the direction it goes. The same trail objects are added for two axes and this leads to performance losses. To solve this, I added a code that changes the rotation of the trail according to direction.


BEFORE:

https://github.com/metanoia83/Godot-4.0-Motion-Trail/assets/52050284/4c0b44e5-b585-46c6-b30d-38b50c9ddb68


AFTER:

https://github.com/metanoia83/Godot-4.0-Motion-Trail/assets/52050284/c2c13632-26e8-4ef9-a1f6-25d44016708f

